### PR TITLE
Deploy GitHub Pages with CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: ruby
+rvm: 2.4.5
+sudo: true
+before_install:
+- wget http://mirrors.kernel.org/ubuntu/pool/main/g/graphviz/graphviz_2.38.0-12ubuntu2_amd64.deb
+- sudo apt install ./graphviz_2.38.0-12ubuntu2_amd64.deb
+- wget -O ~/plantuml.jar https://repo1.maven.org/maven2/net/sourceforge/plantuml/plantuml/1.2020.1/plantuml-1.2020.1.jar
+install:
+- gem install bundler:2.1.4
+- bundle install
+script:
+- asciidoctor index.adoc
+- asciidoctor user_manual/index.adoc -o site/index.html -r asciidoctor-diagram
+- asciidoctor user_manual/index.adoc -o site/scale18x-av-user-manual.pdf -r asciidoctor-pdf
+  -r asciidoctor-diagram -b pdf -a pdf-theme=user_manual/theme.yml
+- cp -r user_manual/assets/ site/
+after_success:
+- "./deploy.sh"
+branches:
+  only:
+  - master
+pro:
+  secure: CgI2SDEG+c7NS7M8qYnACnkLMmpMdVbEKGvE/eWHYt6bBNwLinrGEKnw1W0zA0PhFZLYSgaWg1QRYG4id5tJObZ4jjxL2aCvhFCnjZ+k8RhAeZd8Zu5wjZmNwXg3SNWxrZg8cLOyZ17L/41qXWwsA1+E5uWFnv33+S0s5Df1EJ0=

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem "asciidoctor", "~> 2.0"
 gem "asciidoctor-pdf", "~> 1.5"
 
 gem "asciidoctor-diagram", "~> 2.0"
+
+gem "travis", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,10 +20,35 @@ GEM
       thread_safe (~> 0.3.0)
       treetop (~> 1.6.0)
       ttfunk (~> 1.5.0, >= 1.5.1)
+    backports (3.16.1)
     concurrent-ruby (1.1.6)
+    connection_pool (2.2.2)
     css_parser (1.7.1)
       addressable
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
+    faraday (0.17.3)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.14.0)
+      faraday (>= 0.7.4, < 1.0)
+    ffi (1.12.2)
+    gh (0.14.0)
+      addressable
+      backports
+      faraday (~> 0.8)
+      multi_json (~> 1.0)
+      net-http-persistent (>= 2.7)
+      net-http-pipeline
     hashery (2.1.2)
+    highline (1.7.10)
+    json (2.3.0)
+    launchy (2.5.0)
+      addressable (~> 2.7)
+    multi_json (1.14.1)
+    multipart-post (2.1.1)
+    net-http-persistent (3.1.0)
+      connection_pool (~> 2.2)
+    net-http-pipeline (1.0.1)
     pdf-core (0.7.0)
     pdf-reader (2.4.0)
       Ascii85 (~> 1.0.0)
@@ -46,12 +71,27 @@ GEM
       pdf-reader (~> 2.0)
       prawn (~> 2.2)
     public_suffix (4.0.3)
+    pusher-client (0.6.2)
+      json
+      websocket (~> 1.0)
     ruby-rc4 (0.1.5)
     safe_yaml (1.0.5)
     thread_safe (0.3.6)
+    travis (1.8.11)
+      backports
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9, >= 0.9.1)
+      gh (~> 0.13)
+      highline (~> 1.6)
+      launchy (~> 2.1)
+      pusher-client (~> 0.4)
+      typhoeus (~> 0.6, >= 0.6.8)
     treetop (1.6.10)
       polyglot (~> 0.3)
     ttfunk (1.5.1)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    websocket (1.2.8)
 
 PLATFORMS
   ruby
@@ -60,6 +100,7 @@ DEPENDENCIES
   asciidoctor (~> 2.0)
   asciidoctor-diagram (~> 2.0)
   asciidoctor-pdf (~> 1.5)
+  travis (~> 1.8)
 
 BUNDLED WITH
    2.1.4

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -o errexit -o nounset
+
+git config --global user.email "travis@travis-ci.org"
+git config --global user.name "Travis CI"
+
+git checkout -b gh-pages
+git add .
+git commit -m "Travis build: $TRAVIS_BUILD_NUMBER"
+
+git remote add origin-pages https://$GH_TOKEN@github.com/capsulecorplab/scale-av-web.git > /dev/null 2>&1
+git push -f origin-pages gh-pages

--- a/index.adoc
+++ b/index.adoc
@@ -1,0 +1,39 @@
+= scale-av minimalist webpage
+
+SCALE A/V is the team that handles A/V for the http://socallinuxexpo.org[Southern California Linux Expo], an open source conference.
+
+We consist of volunteers.  The main perks for volunteers include free admission to SCALE, learning new things, getting the bird's eye view of the conference.  And meals are covered for your shifts.
+
+We are currently working on SCALE 18x, which will be at the Pasadena Convention Center on Mar 5-8, 2019.  This will be our fourth time at this venue.
+
+There are many volunteer opportunities for people of any skill level before, during, and after the conference.
+
+== volunteer signup
+
+If you are interested in volunteering with us,
+
+* Sign up https://forms.gle/XmyaohJZc1t1XQs49[here] at your earliest convenience so we can get a good idea of what our staffing will be and whether we need to heavily recruit for certain time slots.  This form asks a number of questions specific to the A/V team and helps us gauge your skills, interests, and availability.
+* Sign up for the https://lists.linuxfests.org/cgi-bin/mailman/listinfo/scale-av[scale-av mailing list].  This is we discuss things relating to A/V and where announcements will be made.  It will get busier as we get closer to SCALE.   Please feel free to ask questions and contribute your ideas.  Don't let March 7th  be the first time we hear from you.
+* Sign up for the https://lists.linuxfests.org/cgi-bin/mailman/listinfo/scale-planning[scale-planning mailing list].  This is where other SCALE volunteers communicate.
+* Bookmark http://socallinuxexpo.github.io/scale-av-web/[this page].  It will be a centralized place to direct people to current scale-av plans and activities.  We will be posting more information as we figure out logistical and technical issues.
+
+== volunteer info
+
+For more information on volunteering with the SCALE A/V team, please refer to the link:./site/index.html[SCALE AV User Manual].
+
+== volunteer timeline
+
+* Most of the before-SCALE activities involve software development and hardware hacking in addition to the usual planning.
+* Mar 3/4 (Tues night,Wed),  we will be setting up the conference rooms and the A/V command center.
+* Mar 5-8 (Thu-Sun),  we will be focused on live video and audio production and troubleshooting.  Volunteer hours are 9-7pm, but A/V support may be required for some evening events.  (NOTE: you are not expected to work the whole day, just whatever times you can manage.)
+* Mar 8 (Sun), once the conference is over,  we could use all the help we can get for tear down.  Most talks will be over by 5:30pm, but we can probably begin teardown of rooms that are no longer being used.
+* After, we will have a post-mortem and finish up with any video editing tasks needed to get all the videos uploaded to Youtube.
+
+== who are you?
+
+You will mainly see e-mails between or from the following people
+
+* Ilan Rabinovitch is the SCALE Conference Chair
+* Michael Proctor Smith is the A/V Chair and handles the technical end with the cameras and video recording
+* Lan Dang is the A/V volunteer coordinator
+* Michael Starch is the Technical lead who owns the majority of the software stack and leads all troubleshooting.

--- a/user_manual/index.adoc
+++ b/user_manual/index.adoc
@@ -3,7 +3,7 @@
 :toclevels: 3
 
 ifndef::backend-pdf[]
-image:https://img.shields.io/badge/License-MIT-yellow.svg[MIT License, link=https://opensource.org/licenses/MIT] image:https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square[PRs Welcome, link=http://makeapullrequest.com] image:https://img.shields.io/badge/Edit%20on-GitHub-orange[Edit on GitHub, link=https://github.com/socallinuxexpo/scale-av-web/edit/master/user_manual/index.adoc]
+image:https://img.shields.io/badge/License-MIT-yellow.svg[MIT License, link=https://opensource.org/licenses/MIT] image:https://img.shields.io/badge/Contribute%20on-GitHub-orange[Contribute on GitHub, link=https://github.com/socallinuxexpo/scale-av-web/] image:https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square[PRs Welcome, link=http://makeapullrequest.com] image:https://img.shields.io/badge/Download%20-PDF-blue[Download PDF link=https://socallinuxexpo.github.io/scale-av-web/site/scale18x-av-user-manual.pdf]
 endif::[]
 
 toc::[]


### PR DESCRIPTION
Closes #8. 

PR extends on #12 for automating build & deployment of GitHub Pages using travis-ci.

Note: This will trigger a travis-ci build once merged to `master` branch. You will need to delete the existing `gh-pages` branch before merging.