### PR TITLE
Print commit hash in documents

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,5 @@
 = SCaLE A/V Coordination =
+:scale-av-user-manual-html: https://socallinuxexpo.github.io/scale-av-web/scale-av-user-manual.html[scale-av-user-manual.html]
 :scale-av-user-manual-pdf: https://socallinuxexpo.github.io/scale-av-web/scale-av-user-manual.pdf[scale-av-user-manual.pdf]
 :user-manual-dir: link:user_manual/[user_manual/]
 :changelog: link:user_manual/CHANGELOG.adoc/[CHANGELOG.adoc]
@@ -10,8 +11,8 @@
 Welcome to the SCaLE A/V Coordination GitHub repo! 
 
 This repo contains source files that serve the dual purpose of generating the
-{scale-av-web} and the {scale-av-user-manual-pdf}, as well as offering a
-wiki and issue tracker for SCaLE A/V logistics and planning.
+{scale-av-web}, {scale-av-user-manual-html}, and {scale-av-user-manual-pdf},
+as well as offering a wiki and issue tracker for SCaLE A/V logistics and planning.
 
 If you are interested in volunteering, please refer to the {scale-av-wiki}.
 
@@ -22,9 +23,9 @@ Pasadena Convention Center.
 
 == Developer Notes ==
 
-Documentation in this repo, including the {scale-av-web} and
-{scale-av-user-manual-pdf}, were generated using {asciidoctor-homepage} - a
-static-site generator for the
+Documentation in this repo, including the {scale-av-web}, {scale-av-user-manual-html},
+and {scale-av-user-manual-pdf}, were generated using {asciidoctor-homepage}
+- a static-site generator for the
 https://asciidoctor.org/docs/asciidoc-syntax-quick-reference[AsciiDoc]
 markup language.
 
@@ -38,7 +39,7 @@ the changes in {changelog}, then commit changes to the `main` branch.
 == Building the documentation locally ==
 
 The following instructions are for building the
-{asciidoctor-homepage} & {scale-av-user-manual-pdf} locally.
+{scale-av-user-manual-html} & {scale-av-user-manual-pdf} documents locally.
 
 === Prerequisites ===
 
@@ -53,7 +54,7 @@ Clone this repo, then change directory into the cloned repo:
 
 === Usage ===
 
-The following will locally generate the {scale-av-user-manual-pdf} to the `public/` folder.
+The following will locally generate the {scale-av-user-manual-html} & {scale-av-user-manual-pdf} documents to the `public/` folder.
 
  ./build.sh
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version=2.0.15
+version=2.0.17
 
 if [ ! -r ./public ]; then
     mkdir public

--- a/build.sh
+++ b/build.sh
@@ -10,14 +10,14 @@ if ! asciidoctor --version | grep $version > /dev/null; then
     echo "asciidoctor $version not installed"
     echo "running build via docker..."
     docker run --rm -v "$PWD:/src" -w "/src" asciidoctor/docker-asciidoctor:1.27.0 asciidoctor index.adoc -o public/index.html
-    docker run --rm -v "$PWD:/src" -w "/src" asciidoctor/docker-asciidoctor:1.27.0 asciidoctor user_manual/index.adoc -o public/scale-av-user-manual.html -r asciidoctor-diagram
-    docker run --rm -v "$PWD:/src" -w "/src" asciidoctor/docker-asciidoctor:1.27.0 asciidoctor user_manual/index.adoc -o public/scale-av-user-manual.pdf -r asciidoctor-pdf -r asciidoctor-diagram -b pdf -a pdf-theme=user_manual/theme.yml
+    docker run --rm -v "$PWD:/src" -w "/src" asciidoctor/docker-asciidoctor:1.27.0 asciidoctor user_manual/index.adoc -o public/scale-av-user-manual.html -acommitHash=$(git rev-parse --short HEAD) -r asciidoctor-diagram
+    docker run --rm -v "$PWD:/src" -w "/src" asciidoctor/docker-asciidoctor:1.27.0 asciidoctor user_manual/index.adoc -o public/scale-av-user-manual.pdf -r asciidoctor-pdf -acommitHash=$(git rev-parse --short HEAD) -r asciidoctor-diagram -b pdf -a pdf-theme=user_manual/theme.yml
 else
     echo "asciidoctor $version installed!"
     echo "running build..."
     asciidoctor index.adoc -o public/index.html
-    asciidoctor user_manual/index.adoc -o public/scale-av-user-manual.html -r asciidoctor-diagram
-    asciidoctor user_manual/index.adoc -o public/scale-av-user-manual.pdf -r asciidoctor-pdf -r asciidoctor-diagram -b pdf -a pdf-theme=user_manual/theme.yml
+    asciidoctor user_manual/index.adoc -o public/scale-av-user-manual.html -acommitHash=$(git rev-parse --short HEAD) -r asciidoctor-diagram
+    asciidoctor user_manual/index.adoc -o public/scale-av-user-manual.pdf -r asciidoctor-pdf -acommitHash=$(git rev-parse --short HEAD) -r asciidoctor-diagram -b pdf -a pdf-theme=user_manual/theme.yml
 fi
 
 cp -r user_manual/assets/ public/

--- a/user_manual/index.adoc
+++ b/user_manual/index.adoc
@@ -1,4 +1,6 @@
+include::version.adoc[]
 = Scale A/V User Manual
+v{version}
 :toc: left
 :toclevels: 3
 

--- a/user_manual/index.adoc
+++ b/user_manual/index.adoc
@@ -4,6 +4,8 @@ v{version}
 :toc: left
 :toclevels: 3
 
+Document generated from https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}]
+
 ifndef::backend-pdf[]
 image:https://img.shields.io/badge/License-MIT-yellow.svg[MIT License, link=https://opensource.org/licenses/MIT] image:https://img.shields.io/badge/Contribute%20on-GitHub-orange[Contribute on GitHub, link=https://github.com/socallinuxexpo/scale-av-web/] image:https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square[PRs Welcome, link=http://makeapullrequest.com] image:https://img.shields.io/badge/Download%20-PDF-blue[Download PDF, link=./scale-av-user-manual.pdf]
 endif::[]

--- a/user_manual/theme.yml
+++ b/user_manual/theme.yml
@@ -3,7 +3,7 @@ footer:
   columns: =100%
   recto:
     center:
-      content: '{section-or-chapter-title} | *{page-number}* | v{version}'
+      content: '{section-or-chapter-title} | *{page-number}* | v{version} https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}]'
   verso:
     center:
-      content: '{section-or-chapter-title} | *{page-number}* | v{version}'
+      content: '{section-or-chapter-title} | *{page-number}* | v{version} https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}]'

--- a/user_manual/version.adoc
+++ b/user_manual/version.adoc
@@ -1,0 +1,1 @@
+:version: 1.3-{commitHash}

--- a/user_manual/version.adoc
+++ b/user_manual/version.adoc
@@ -1,1 +1,1 @@
-:version: 1.3-{commitHash}
+:version: 1.3


### PR DESCRIPTION
PR prints link to commit hash in HTML & PDF documents for SCaLE A/V user manual from which documents were generated.

Noteworthy changes:
- `:version:` attribute was moved from `CHANGELOG.adoc` to `version.adoc` as to be able to print version no. directly underneath page title 

Preview of user manual available on GitHub Pages in forked repo:
- HTML: https://capsulecorplab.github.io/scale-av-web/scale-av-user-manual.html
- PDF: https://capsulecorplab.github.io/scale-av-web/scale-av-user-manual.pdf

closes #23 