### PR TITLE
Add Commit date

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,7 +53,7 @@ fi
 
 #### generate scale av user manual as pdf ####
 clitool="asciidoctor"
-cmdargs="user_manual/index.adoc -o dist/scale-av-user-manual.pdf -r asciidoctor-pdf -acommitHash=$(git rev-parse --short HEAD) -r asciidoctor-diagram -b pdf -a pdf-theme=user_manual/theme.yml"
+cmdargs="user_manual/index.adoc -o dist/scale-av-user-manual.pdf -r asciidoctor-pdf -acommitHash=$(git rev-parse --short HEAD) -acommitDate=$(git show -s --format=%ci HEAD) -r asciidoctor-diagram -b pdf -a pdf-theme=user_manual/theme.yml"
 cmd="$clitool $cmdargs"
 workdir=$project_root
 podmancmd="podman run --rm -v "$PWD:/src" -w "/src" docker.io/asciidoctor/docker-asciidoctor:1.27.0 $cmd"

--- a/build.sh
+++ b/build.sh
@@ -53,7 +53,7 @@ fi
 
 #### generate scale av user manual as pdf ####
 clitool="asciidoctor"
-cmdargs="user_manual/index.adoc -o dist/scale-av-user-manual.pdf -r asciidoctor-pdf -acommitHash=$(git rev-parse --short HEAD) -acommitDate=$(git show -s --format=%ci HEAD) -r asciidoctor-diagram -b pdf -a pdf-theme=user_manual/theme.yml"
+cmdargs="user_manual/index.adoc -o dist/scale-av-user-manual.pdf -r asciidoctor-pdf -acommitHash=$(git rev-parse --short HEAD) -acommitDate=$(git show -s --format=%cI HEAD) -r asciidoctor-diagram -b pdf -a pdf-theme=user_manual/theme.yml"
 cmd="$clitool $cmdargs"
 workdir=$project_root
 podmancmd="podman run --rm -v "$PWD:/src" -w "/src" docker.io/asciidoctor/docker-asciidoctor:1.27.0 $cmd"

--- a/user_manual/index.adoc
+++ b/user_manual/index.adoc
@@ -3,7 +3,6 @@ include::version.adoc[]
 v{version}
 Document generated from https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}]
 Last Updated: {commitDate}
-
 :toc: left
 :toclevels: 3
 

--- a/user_manual/index.adoc
+++ b/user_manual/index.adoc
@@ -1,11 +1,12 @@
 include::version.adoc[]
 = Scale A/V User Manual
 v{version}
-Document generated from https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}]
-Last Updated: {commitDate}
 :toc: left
 :toclevels: 3
 
+Last Updated: {commitDate}
+
+Document generated from https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}]
 
 ifndef::backend-pdf[]
 image:https://img.shields.io/badge/License-MIT-yellow.svg[MIT License, link=https://opensource.org/licenses/MIT] image:https://img.shields.io/badge/Contribute%20on-GitHub-orange[Contribute on GitHub, link=https://github.com/socallinuxexpo/scale-av-web/] image:https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square[PRs Welcome, link=http://makeapullrequest.com] image:https://img.shields.io/badge/Download%20-PDF-blue[Download PDF, link=./scale-av-user-manual.pdf]

--- a/user_manual/index.adoc
+++ b/user_manual/index.adoc
@@ -5,6 +5,7 @@ v{version}
 :toclevels: 3
 
 Document generated from https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}]
+Last Updated: {commitDate}
 
 ifndef::backend-pdf[]
 image:https://img.shields.io/badge/License-MIT-yellow.svg[MIT License, link=https://opensource.org/licenses/MIT] image:https://img.shields.io/badge/Contribute%20on-GitHub-orange[Contribute on GitHub, link=https://github.com/socallinuxexpo/scale-av-web/] image:https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square[PRs Welcome, link=http://makeapullrequest.com] image:https://img.shields.io/badge/Download%20-PDF-blue[Download PDF, link=./scale-av-user-manual.pdf]

--- a/user_manual/index.adoc
+++ b/user_manual/index.adoc
@@ -1,11 +1,12 @@
 include::version.adoc[]
 = Scale A/V User Manual
 v{version}
+Document generated from https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}]
+Last Updated: {commitDate}
+
 :toc: left
 :toclevels: 3
 
-Document generated from https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}]
-Last Updated: {commitDate}
 
 ifndef::backend-pdf[]
 image:https://img.shields.io/badge/License-MIT-yellow.svg[MIT License, link=https://opensource.org/licenses/MIT] image:https://img.shields.io/badge/Contribute%20on-GitHub-orange[Contribute on GitHub, link=https://github.com/socallinuxexpo/scale-av-web/] image:https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square[PRs Welcome, link=http://makeapullrequest.com] image:https://img.shields.io/badge/Download%20-PDF-blue[Download PDF, link=./scale-av-user-manual.pdf]

--- a/user_manual/theme.yml
+++ b/user_manual/theme.yml
@@ -3,7 +3,7 @@ footer:
   columns: =100%
   recto:
     center:
-      content: '{section-or-chapter-title} | *{page-number}* | v{version} https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}]'
+      content: '{section-or-chapter-title} | *{page-number}* | v{version} https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}] | {commitDate}'
   verso:
     center:
-      content: '{section-or-chapter-title} | *{page-number}* | v{version} https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}]'
+      content: '{section-or-chapter-title} | *{page-number}* | v{version} https://github.com/socallinuxexpo/scale-av-web/commit/{commitHash}[{commitHash}] | {commitDate}'


### PR DESCRIPTION
Commit hashes aren't very helpful for the PDF printouts. So I added a new var to the build script to inject a commit date that can be used in the doc as commitDate. I also moved the doc info like commit/commitDate to the top before the TOC so that it's more easily seen